### PR TITLE
get default Frontendcontroller by PageId

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -14,15 +14,6 @@ class ConfigurationUtility
     const EXTENSION = 'my_redirects';
 
     /**
-     * @return integer
-     */
-    public static function getDefaultRootPageId()
-    {
-        $configuration = static::getConfiguration();
-        return (int)($configuration['defaultRootPageId'] ?: ($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DEFAULT']['pagePath']['rootpage_id'] ?: 1));
-    }
-
-    /**
      * Get configured excluded parameters to keep in redirect
      *
      * @return array


### PR DESCRIPTION
Loads correct TSFE based on the destination page ID, which will allow multiple site / domain configuration to respect the correct RealURL settings. Without this fix, only links for the "first domain" will be handled.